### PR TITLE
Fix metadata and sitemap URLs to use akoder.xyz

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -7,6 +7,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: "/private/",
     },
-    sitemap: "https://root.akoder.xyz/sitemap.xml",
+    sitemap: "https://akoder.xyz/sitemap.xml",
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,7 +3,7 @@ import type { MetadataRoute } from "next";
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://root.akoder.xyz/",
+      url: "https://akoder.xyz/",
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 1,


### PR DESCRIPTION
Updated `app/layout.tsx`, `app/robots.ts`, and `app/sitemap.ts` to replace `https://root.akoder.xyz` with `https://akoder.xyz` as requested. This fixes issues with metadata not showing up correctly on external platforms.

---
*PR created automatically by Jules for task [14838104603366488921](https://jules.google.com/task/14838104603366488921) started by @AdityaKodez*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain references in search engine configuration and site metadata files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->