### PR TITLE
Prevent transient scrollbar in GitHub map by constraining overflow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,11 +17,9 @@ export default async function Home() {
   return (
     <main className="relative min-h-screen max-w-3xl mx-auto py-8 md:pt-16 space-y-8 border border-dashed overflow-hidden">
       <Hero />
-      <div className="overflow-y-auto">
-        <Suspense fallback={<GitSkeleton />}>
-          <GitHubCalendar data={contributionData} />
-        </Suspense>
-      </div>
+      <Suspense fallback={<GitSkeleton />}>
+        <GitHubCalendar data={contributionData} />
+      </Suspense>
       <Skills />
       <About />
       <Testimonials />

--- a/components/skeletons/github-skeleton.tsx
+++ b/components/skeletons/github-skeleton.tsx
@@ -7,7 +7,7 @@ export const GitSkeleton = () => {
   const days = Array.from({ length: 7 });
 
   return (
-    <div className="p-4 border-y border-dashed overflow-x-auto">
+    <div className="p-4 border-y border-dashed overflow-x-auto overflow-y-hidden">
       <div className="flex flex-col gap-2">
         {/* Month Labels Skeleton */}
         <div className="flex w-full justify-between gap-2 mb-1 h-4 relative">

--- a/components/ui/github-map.tsx
+++ b/components/ui/github-map.tsx
@@ -137,7 +137,7 @@ const GitHubCalendar = ({
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.3 }}
-      className="p-4 border-y border-dashed"
+      className="p-4 border-y border-dashed overflow-x-auto overflow-y-hidden"
     >
       <div className="flex">
         <div>


### PR DESCRIPTION
### Motivation
- The GitHub contributions map produced a transient vertical scrollbar while data was loading because an outer wrapper applied `overflow-y-auto` during the `Suspense` fallback transition.
- The intent is to keep horizontal scrolling for wide calendars but prevent vertical scroll flashes by scoping overflow styles to the map and its skeleton only.

### Description
- Removed the extra `div` with `overflow-y-auto` around the `Suspense`/`GitHubCalendar` in `app/page.tsx` so the outer layout no longer introduces a vertical scrollbar.
- Constrained the calendar container to horizontal overflow only by adding `overflow-x-auto overflow-y-hidden` to the motion wrapper in `components/ui/github-map.tsx`.
- Applied the same `overflow-x-auto overflow-y-hidden` cleanup to the skeleton in `components/skeletons/github-skeleton.tsx` so the fallback layout won't flash a vertical scrollbar.

### Testing
- Started the dev server with `npm run dev`, which launched successfully but requests returned `500` due to a missing environment variable `GITHUB_TOKEN` (failure to fully render remote data).
- Ran a Playwright screenshot script that navigated to the local server and produced `artifacts/github-map.png` (succeeded in capturing the page state despite the token error).
- Noted compile/runtime warnings about Google Fonts failing to download due to network/resource issues, which did not affect the overflow change itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69820c04a4d4832586d87df6c6226e26)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout structure and scroll behavior of the GitHub contribution calendar
  * Enhanced overflow handling to optimize vertical and horizontal scrolling across the calendar display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->