### PR TITLE
Use absolute URLs for Open Graph and Twitter images

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -49,7 +49,7 @@ export const metadata: Metadata = {
     type: "website",
     images: [
       {
-        url: "/profile.png",
+        url: "https://akoder.xyz/profile.png",
         width: 1200,
         height: 630,
         alt: "Aditya — Full-Stack Web Developer",
@@ -62,7 +62,7 @@ export const metadata: Metadata = {
     title: "Aditya — Full-Stack Web Developer",
     description:
       "Building fast, scalable SaaS products with Next.js and modern web tech.",
-    images: ["/profile.png"],
+    images: ["https://akoder.xyz/profile.png"],
     creator: "@AdityaKodez",
   },
 


### PR DESCRIPTION
### Motivation
- Ensure social crawlers can fetch the OG image reliably by using absolute image URLs so preview tools don't fail to resolve a site-relative path.

### Description
- Updated `app/layout.tsx` to replace `"/profile.png"` with `"https://akoder.xyz/profile.png"` for the `openGraph.images[0].url` and `twitter.images` entries.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821fc21f2c8325a2b7180c4f64583a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed social media preview images to display correctly when pages are shared on social platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->