### PR TITLE
Refine hero messaging, stack visibility, and Discord tooltip copy

### DIFF
--- a/components/discord-status.tsx
+++ b/components/discord-status.tsx
@@ -176,7 +176,7 @@ function TooltipBody({ data }: { data: LanyardData }) {
     return <p>Currently offline</p>;
   }
 
-  return <p>Nothing active right now</p>;
+  return <p>No activity right now.</p>;
 }
 
 export function DiscordStatus() {
@@ -223,7 +223,10 @@ export function DiscordStatus() {
         </div>
       </TooltipTrigger>
       <TooltipContent side="bottom" className="p-2.5">
-        <TooltipBody data={data} />
+        <div className="space-y-1">
+          <TooltipBody data={data} />
+          <p className="text-[10px] text-muted-foreground">From Discord status</p>
+        </div>
       </TooltipContent>
     </Tooltip>
   );

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -156,7 +156,7 @@ export function Hero() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.2, delay: 0.3 }}
           >
-            Built and shipped 2 full-stack products with{" "}
+            Built and shipped full-stack products with{" "}
             <span className="underline underline-offset-4 decoration-border/50">
               real users
             </span>

--- a/components/skills.tsx
+++ b/components/skills.tsx
@@ -1,10 +1,4 @@
 "use client";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { motion } from "motion/react";
 import NextjsIcon from "@/public/stacks/nextjs";
 import ReactIcon from "@/public/stacks/react";
@@ -37,28 +31,25 @@ export function Skills() {
       >
         Stack
       </motion.h2>
-      <TooltipProvider delayDuration={0}>
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.3, delay: 0.1 }}
-          className="flex flex-wrap gap-5 px-6"
-        >
-          {skills.map((skill) => (
-            <Tooltip key={skill.name}>
-              <TooltipTrigger asChild>
-                <div className="grayscale hover:grayscale-0 transition-all duration-300 cursor-help">
-                  <skill.icon size="24" />
-                </div>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p className="text-xs font-medium">{skill.name}</p>
-              </TooltipContent>
-            </Tooltip>
-          ))}
-        </motion.div>
-      </TooltipProvider>
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.3, delay: 0.1 }}
+        className="flex flex-wrap gap-5 px-6"
+      >
+        {skills.map((skill) => (
+          <div
+            key={skill.name}
+            className="rounded-sm border border-dashed px-2 py-1"
+          >
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              <skill.icon size="20" />
+              <span className="text-xs">{skill.name}</span>
+            </div>
+          </div>
+        ))}
+      </motion.div>
     </section>
   );
 }

--- a/components/skills.tsx
+++ b/components/skills.tsx
@@ -36,15 +36,15 @@ export function Skills() {
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
         transition={{ duration: 0.3, delay: 0.1 }}
-        className="flex flex-wrap gap-2.5 px-6"
+        className="flex flex-wrap gap-3 px-6"
       >
         {skills.map((skill) => (
           <div
             key={skill.name}
-            className="rounded-sm border border-dashed px-1.5 py-0.5"
+            className="rounded-sm border border-dashed px-2 py-1"
           >
-            <div className="flex items-center gap-1 text-xs text-muted-foreground">
-              <skill.icon size="16" />
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              <skill.icon size="20" />
               <span className="text-xs">{skill.name}</span>
             </div>
           </div>

--- a/components/skills.tsx
+++ b/components/skills.tsx
@@ -36,15 +36,15 @@ export function Skills() {
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
         transition={{ duration: 0.3, delay: 0.1 }}
-        className="flex flex-wrap gap-5 px-6"
+        className="flex flex-wrap gap-2.5 px-6"
       >
         {skills.map((skill) => (
           <div
             key={skill.name}
-            className="rounded-sm border border-dashed px-2 py-1"
+            className="rounded-sm border border-dashed px-1.5 py-0.5"
           >
-            <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
-              <skill.icon size="20" />
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <skill.icon size="16" />
               <span className="text-xs">{skill.name}</span>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Make the hero copy stronger by removing the numeric qualifier from the products statement. 
- Improve the Stack section UX so technology names are visible without needing to hover. 
- Fix a grammatically awkward Discord tooltip fallback and add a small source note for clarity.

### Description
- Updated `components/hero.tsx` to change the copy from “Built and shipped 2 full-stack products…” to “Built and shipped full-stack products…”.
- Reworked `components/skills.tsx` to remove per-icon tooltips and `TooltipProvider` usage and render labeled pill-like items with each icon and its `skill.name` visible by default. 
- Updated `components/discord-status.tsx` to change the fallback message to `"No activity right now."` and add a small caption `"From Discord status"` inside the tooltip content.

### Testing
- Ran `npm run lint` and the lint step completed successfully. 
- Launched the dev server with `npm run dev`; the server started but page rendering returned a runtime 500 due to a missing `GITHUB_TOKEN` and external Google Fonts fetch warnings. 
- Captured a full-page screenshot of the running app via an automated Playwright script which completed and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699055ecd6588325bb33645582800dae)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated Discord status tooltip wording and layout; added a muted timestamp line and extra vertical spacing.
  * Simplified skills display to a compact bordered layout with smaller icons and adjusted spacing; removed tooltip-based hover reveal so icons and names are always visible.
  * Minor copy update in the hero paragraph (removed a numeric qualifier).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->