### PR TITLE
Fix hero header control alignment

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -96,7 +96,7 @@ export function Hero() {
                 ref={buttonRef}
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8 cursor-pointer rounded-none"
+                className="h-8 w-8 cursor-pointer rounded-none border-0"
                 onClick={() => {
                   toggleTheme();
                 }}
@@ -152,7 +152,7 @@ export function Hero() {
             Next.js and Prisma.
           </motion.h1>
           <motion.p
-            className="no-js-visible text-md max-sm:text-sm text-muted-foreground"
+            className="no-js-visible mt-2 text-md max-sm:text-sm text-muted-foreground"
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.2, delay: 0.3 }}

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -73,14 +73,14 @@ export function Hero() {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.2, ease: "easeOut" }}
     >
-      <div className="flex justify-end items-center">
-        <div className="border-r pr-2">
+      <div className="flex items-center justify-end">
+        <div className="flex items-center overflow-hidden rounded-md border border-border/60 divide-x divide-border/60">
           <Tooltip>
             <TooltipTrigger asChild>
               <Link
                 href="https://github.com/AdityaKodez/adityaojha"
                 target="_blank"
-                className="text-muted-foreground hover:text-foreground transition-colors"
+                className="flex h-8 w-8 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
               >
                 <OpenSrc size="20" />
               </Link>
@@ -89,30 +89,30 @@ export function Hero() {
               <p>This project is open source !</p>
             </TooltipContent>
           </Tooltip>
-        </div>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              ref={buttonRef}
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 cursor-pointer border-r"
-              onClick={() => {
-                toggleTheme();
-              }}
-            >
-              <Sun className="h-4 w-4 rotate-0 scale-100 transition-transform dark:-rotate-90 dark:scale-0" />
-              <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-transform dark:rotate-0 dark:scale-100" />
-              <span className="sr-only">Toggle theme</span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>
-              Toggle theme <Kbd>D</Kbd>
-            </p>
-          </TooltipContent>
-        </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                ref={buttonRef}
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 cursor-pointer rounded-none"
+                onClick={() => {
+                  toggleTheme();
+                }}
+              >
+                <Sun className="h-4 w-4 rotate-0 scale-100 transition-transform dark:-rotate-90 dark:scale-0" />
+                <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-transform dark:rotate-0 dark:scale-100" />
+                <span className="sr-only">Toggle theme</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>
+                Toggle theme <Kbd>D</Kbd>
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
       </div>
 
       <audio ref={audioRef} src="/switch.mp3" preload="auto" />


### PR DESCRIPTION
### Motivation
- Ensure the open-source icon and theme toggle are visually aligned with equal gaps so the header border and divider read cleanly.

### Description
- Refactored the header controls into a single bordered container in `components/hero.tsx` using `div` with `overflow-hidden rounded-md border border-border/60 divide-x divide-border/60` for a consistent frame.
- Made both controls equal hit areas by applying `h-8 w-8` and centering their content so spacing and alignment match.
- Removed individual right borders and applied `rounded-none` to the toggle `Button` to avoid conflicting edge radii inside the shared container.

### Testing
- Ran `npm run lint`, which completed successfully.
- Started the dev server with `GITHUB_TOKEN=dummy npm run dev -- --port 3000`; the server started but page rendering was impacted by external network fetch failures to Google Fonts and the GitHub API which prevented full visual verification.
- Captured a Playwright screenshot at `artifacts/hero-header-fix.png` to validate layout changes, but the runtime external fetch errors limited complete verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699274c5670883258dfe1675f57f0273)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Restructured header layout for clearer grouping and visual boundaries
  * GitHub link redesigned as a compact square icon button with hover behavior
  * Theme toggle restyled as a ghost icon button with refined transitions and moved into the bordered group; tooltip preserved
  * Improved intro paragraph spacing for better vertical rhythm
  * Keyboard shortcuts and related interactions remain intact
<!-- end of auto-generated comment: release notes by coderabbit.ai -->