### PR TITLE
Add small footer with heart icon and copyright line

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,18 +32,16 @@ export default async function Home() {
         <GitHubCalendar data={contributionData} />
       </Suspense>
       <CTA />
-      <footer className="mx-4 mb-8 rounded-2xl border border-dashed bg-muted/20 px-4 py-6 text-center">
-        <div className="mx-auto flex max-w-sm flex-col items-center gap-2 text-sm text-muted-foreground">
-          <p className="inline-flex items-center justify-center gap-1.5 font-medium text-foreground">
-            Designed &amp; Made with
-            <Heart className="size-4 fill-rose-500 text-rose-500" />
-          </p>
-          <p className="text-xs sm:text-sm">
-            © {new Date().getFullYear()} Aditya. All rights reserved.
-          </p>
-        </div>
-      </footer>
-
+ <footer className="mt-12 border-t py-8 text-left text-sm text-muted-foreground">
+  <div className="container flex flex-col gap-1">
+    <p className="font-medium text-foreground flex items-center gap-1">
+      Designed & Made by Aditya with <Heart className="w-4 h-4 text-red-700 fill-red-400" />
+    </p>
+    <p className="text-xs">
+      © {new Date().getFullYear()} All rights reserved.
+    </p>
+  </div>
+</footer>
       {/* Progressive Blur - Fixed to bottom of viewport */}
       <div className="fixed bottom-0 left-0 right-0 z-50 mx-auto w-full max-w-3xl pointer-events-none">
         <ProgressiveBlur position="bottom" height="100px" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import { GitHubCalendar } from "@/components/ui/github-map";
 import { ProgressiveBlur } from "@/components/ui/progressive-blur";
 import { ZenoProject } from "@/components/zeno-project";
 import { fetchGithubData } from "@/lib/github";
+import { Heart } from "lucide-react";
 import { Suspense } from "react";
 export default async function Home() {
   const contributionData = await fetchGithubData("AdityaKodez");
@@ -31,6 +32,13 @@ export default async function Home() {
         <GitHubCalendar data={contributionData} />
       </Suspense>
       <CTA />
+      <footer className="pb-8 text-center text-sm text-muted-foreground space-y-1">
+        <p className="inline-flex items-center gap-1">
+          Designed &amp; Made with
+          <Heart className="size-4 fill-red-500 text-red-500" />
+        </p>
+        <p>© {new Date().getFullYear()} Aditya. All rights reserved.</p>
+      </footer>
 
       {/* Progressive Blur - Fixed to bottom of viewport */}
       <div className="fixed bottom-0 left-0 right-0 z-50 mx-auto w-full max-w-3xl pointer-events-none">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,12 +32,16 @@ export default async function Home() {
         <GitHubCalendar data={contributionData} />
       </Suspense>
       <CTA />
-      <footer className="pb-8 text-center text-sm text-muted-foreground space-y-1">
-        <p className="inline-flex items-center gap-1">
-          Designed &amp; Made with
-          <Heart className="size-4 fill-red-500 text-red-500" />
-        </p>
-        <p>© {new Date().getFullYear()} Aditya. All rights reserved.</p>
+      <footer className="mx-4 mb-8 rounded-2xl border border-dashed bg-muted/20 px-4 py-6 text-center">
+        <div className="mx-auto flex max-w-sm flex-col items-center gap-2 text-sm text-muted-foreground">
+          <p className="inline-flex items-center justify-center gap-1.5 font-medium text-foreground">
+            Designed &amp; Made with
+            <Heart className="size-4 fill-rose-500 text-rose-500" />
+          </p>
+          <p className="text-xs sm:text-sm">
+            © {new Date().getFullYear()} Aditya. All rights reserved.
+          </p>
+        </div>
       </footer>
 
       {/* Progressive Blur - Fixed to bottom of viewport */}


### PR DESCRIPTION
### Motivation
- Add a compact footer under the CTA that shows “Designed & Made with ❤️” (using a filled Lucide heart icon) and a copyright line so the site has a simple attribution at the bottom of the home page.

### Description
- Import `Heart` from `lucide-react` and add a `<footer>` block in `app/page.tsx` containing the text, the `Heart` icon with fill styling, and a dynamic year (`© {new Date().getFullYear()} Aditya`).

### Testing
- Ran `npm run lint` which completed successfully, started the dev server with `npm run dev` (server booted), and captured a Playwright screenshot to verify the footer rendered, though unrelated runtime network warnings for Google Fonts/GitHub API occurred in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69928f68edb883259c5033a26f3b7944)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a footer with branding text "Designed & Made by Aditya with" plus a heart icon.
  * Footer includes the current year and rights line, and appears below the CTA on the home page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->