### PR TITLE
fix: resolve TypeScript error in skillIconMap definition

### DIFF
--- a/components/skills.tsx
+++ b/components/skills.tsx
@@ -13,7 +13,7 @@ import TrpcIcon from "@/public/stacks/trcp";
 import TSIcon from "@/public/stacks/ts";
 import type { ComponentType } from "react";
 
-const skillIconMap: Record<SkillIcon, ComponentType<{ size?: string }>> = {
+const skillIconMap: Record<SkillIcon, ComponentType<{ size: string }>> = {
   nextjs: NextjsIcon,
   react: ReactIcon,
   typescript: TSIcon,


### PR DESCRIPTION
Updated `skillIconMap` type definition in `components/skills.tsx` to require `size` prop as a string. This resolves a TypeScript error where icon components requiring a `size` prop were being assigned to a type that allowed `size` to be optional. Verified by running `npm run build`.

---
*PR created automatically by Jules for task [2121142399446509716](https://jules.google.com/task/2121142399446509716) started by @AdityaKodez*