### PR TITLE
Align footer contact hover style with social cards and add YouTube bookmark

### DIFF
--- a/components/cta.tsx
+++ b/components/cta.tsx
@@ -51,16 +51,20 @@ export function CTA() {
         <div className="grid border-t border-dashed grid-cols-3 max-sm:grid-cols-1 overflow-hidden">
           {contactChannels.map((channel) => {
             const content = (
-              <div className="group flex items-center gap-3 p-4 border-b border-r border-dashed max-sm:border-r-0 transition-colors hover:bg-muted/50">
-                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-sm border text-muted-foreground group-hover:text-foreground group-hover:border-foreground/30 transition-colors">
+              <div className="group relative flex items-center gap-3 p-4 border-b border-r border-dashed max-sm:border-r-0 transition-colors hover:bg-muted/10 overflow-hidden">
+                <div className="absolute inset-0 blueprint-bg opacity-50 group-hover:opacity-100 transition-opacity pointer-events-none" />
+                <div className="absolute inset-0 ring-1 ring-inset ring-muted-foreground/5 group-hover:ring-muted-foreground/10 transition-colors pointer-events-none" />
+
+                <div className="relative z-10 flex h-9 w-9 shrink-0 items-center justify-center rounded-sm text-muted-foreground group-hover:text-foreground transition-colors bg-background">
                   <ContactIcon icon={channel.icon} />
+                  <div className="absolute inset-0 ring-1 ring-inset ring-muted-foreground/5 pointer-events-none rounded-sm"></div>
                 </div>
-                <div className="flex flex-col min-w-0">
+                <div className="relative z-10 flex flex-col min-w-0">
                   <span className="text-sm font-medium leading-none">{channel.platform}</span>
                   <span className="text-xs text-muted-foreground mt-1 truncate">{channel.handle}</span>
                 </div>
                 {channel.action === "copy" ? (
-                  <div className="ml-auto">
+                  <div className="relative z-10 ml-auto">
                     {copiedField === channel.id ? (
                       <Check className="h-3.5 w-3.5 text-green-500" />
                     ) : (

--- a/config/site.ts
+++ b/config/site.ts
@@ -213,6 +213,13 @@ export const siteConfig: PortfolioConfig = {
         domain: "x.com",
         icon: X,
       },
+      {
+        id: "7",
+        url: "https://youtu.be/aStHTTPxlis?si=VoWpllxMa1Ihphro",
+        title: "How Elon Work",
+        domain: "youtube.com",
+        icon: FaYoutube,
+      },
     ],
   },
 };


### PR DESCRIPTION
### Motivation
- Make the footer/contact cards visually consistent with the Social cards by reusing the same hover texture and inset-ring treatment to improve UI cohesion.
- Ensure the contact icon and text remain crisp and accessible above the hover overlays by matching the social card layering pattern.
- Preserve an earlier update that adds a YouTube bookmark to the bookmarks list so the video shows in the Bookmarks section.

### Description
- Updated `components/cta.tsx` to add the blueprint hover texture, inset ring hover overlay, and `z-10` layering so footer contact cards match the Social cards' hover pattern and behavior.
- Adjusted the contact icon container and surrounding elements to use the same layered structure and ring element as `components/social.tsx` for consistent visuals.
- Added the YouTube bookmark entry to `config/site.ts` (id `7`, title `How Elon Work`, `url` set to the provided YouTube link) so it appears in the Bookmarks section.

### Testing
- Ran `npm run lint`, which failed due to a pre-existing unrelated lint rule violation in `config/types.ts` (`@typescript-eslint/no-explicit-any`) and is not introduced by these changes.
- Started the dev server with `npm run dev` and successfully loaded the app for visual verification on `http://localhost:3000`.
- Captured a visual verification screenshot of the updated footer hover state at `artifacts/footer-hover-pattern.png` using a Playwright script, which confirmed the hover pattern rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d4b716e148325bb0c1d4fb30935fb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new bookmark resource

* **Style**
  * Improved visual design of contact channel items with enhanced layering and decorative elements
  * Refined hover interactions and visual depth effects
  * Better visual hierarchy and stacking presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->