### PR TITLE
chore: version bump to 0.2.0 and generate release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-03-05
+
+### Added
+- **Major Design Overhaul**: Redesigned the entire layout and UI components.
+- **Enhanced Skills Section**: Included more skills and technologies in the skills section.
+- **Sortable Functionality**: Added new drag-and-drop sortable features using `@dnd-kit`.
+- **New UI Components**: Introduced various new components including `infinite-slider`, `github-map`, `discord-status`, `testimonials`, `certifications`, and multiple base Shadcn UI components.
+- **Motion & Animations**: Integrated Framer Motion and custom animated components (e.g., `ElectricBorder`).
+- **Complete Refactoring**: Restructured app layout, pages, config files, and hooks. Over 100 files updated/added.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portfolio",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portfolio",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@base-ui/react": "^1.1.0",
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
This PR addresses the request to generate release notes summarizing the recent PR/commit and bumps the project's version from `0.1.0` to `0.2.0`.

A new `CHANGELOG.md` file was created summarizing the major changes (design overhaul, new UI components, `@dnd-kit` sortable features, Framer Motion integration, and over 100 files updated/added) included in the initial massive commit `6801c74`. Version numbers in `package.json` and `package-lock.json` were also updated using `npm version minor`.

---
*PR created automatically by Jules for task [8970077126610317689](https://jules.google.com/task/8970077126610317689) started by @AdityaKodez*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.2.0

* **New Features**
  * Complete design overhaul with refreshed layout and UI components
  * Drag-and-drop sorting functionality across the app
  * Expanded Skills section with additional technologies
  * New components: infinite slider, GitHub map, Discord status display, testimonials, and certifications
  * Enhanced animations and motion effects throughout the interface

* **Chores**
  * Version bumped to 0.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->