### PR TITLE
🔒 Add missing rel="noopener noreferrer" on external links

### DIFF
--- a/app/project/[id]/project-content.tsx
+++ b/app/project/[id]/project-content.tsx
@@ -109,7 +109,7 @@ export function ProjectContent({ project }: { project: Project }) {
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button asChild>
-                      <Link href={project.liveUrl} target="_blank">
+                      <Link href={project.liveUrl} target="_blank" rel="noopener noreferrer">
                         Live Preview <ForwardIcon className="ml-2 h-4 w-4" />
                       </Link>
                     </Button>
@@ -123,7 +123,7 @@ export function ProjectContent({ project }: { project: Project }) {
 
             {project.githubUrl && (
               <Button asChild variant="outline">
-                <Link href={project.githubUrl} target="_blank">
+                <Link href={project.githubUrl} target="_blank" rel="noopener noreferrer">
                   <FaGithub className="mr-2 h-4 w-4" />
                   Source Code
                 </Link>

--- a/components/banner.tsx
+++ b/components/banner.tsx
@@ -109,6 +109,7 @@ export function Banner() {
               <Link
                 href={siteConfig.banner.openSourceUrl}
                 target="_blank"
+                rel="noopener noreferrer"
                 className="flex h-8 items-center justify-center gap-1 px-2 text-white/70 transition-colors hover:text-white"
               >
                 <OpenSrc size="20" />

--- a/components/cta.tsx
+++ b/components/cta.tsx
@@ -117,7 +117,7 @@ export function CTA() {
             return (
               <Tooltip key={channel.id}>
                 <TooltipTrigger asChild>
-                  <Link href={channel.href ?? "#"} target="_blank" className="focus-visible:outline-none">
+                  <Link href={channel.href ?? "#"} target="_blank" rel="noopener noreferrer" className="focus-visible:outline-none">
                     {content}
                   </Link>
                 </TooltipTrigger>

--- a/components/social.tsx
+++ b/components/social.tsx
@@ -174,6 +174,7 @@ const Social = () => {
                 <Link
                   href={social.href ?? "#"}
                   target={social.action === "external" ? "_blank" : undefined}
+                  rel={social.action === "external" ? "noopener noreferrer" : undefined}
                   className="group micro-press block focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/20 focus-visible:ring-offset-0"
                 >
                   {cellContent}

--- a/components/zeno-project.tsx
+++ b/components/zeno-project.tsx
@@ -100,7 +100,7 @@ function ProjectCard({
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <Button asChild variant="outline" size="sm" className="w-fit">
-                          <Link href={project.liveUrl} target="_blank">
+                          <Link href={project.liveUrl} target="_blank" rel="noopener noreferrer">
                             {projectsSectionConfig.liveButtonLabel}{" "}
                             <LuExternalLink className="ml-1.5 h-3 w-3" />
                           </Link>
@@ -116,6 +116,7 @@ function ProjectCard({
                     <Link
                       href={project.githubUrl}
                       target="_blank"
+                      rel="noopener noreferrer"
                       className="micro-transition flex items-center gap-2 text-xs hover:text-primary focus-visible:outline-none focus-visible:text-primary"
                     >
                       <FaGithub className="size-4" />
@@ -169,7 +170,7 @@ function ProjectCard({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button asChild variant="outline" size="sm" className="shrink-0">
-                        <Link href={project.liveUrl} target="_blank">
+                        <Link href={project.liveUrl} target="_blank" rel="noopener noreferrer">
                           {projectsSectionConfig.liveButtonLabel}{" "}
                           <LuExternalLink className="ml-1.5 h-3 w-3" />
                         </Link>


### PR DESCRIPTION
🎯 **What:** Missing `rel="noopener noreferrer"` attribute on Next.js `<Link>` elements pointing externally using `target="_blank"`.
⚠️ **Risk:** Tab-nabbing security vulnerability allowing the newly opened tab to potentially control the original page via `window.opener`, alongside potential privacy leaks via the `Referer` header.
🛡️ **Solution:** Appended `rel="noopener noreferrer"` to external links in `components/cta.tsx`, `components/social.tsx`, `components/zeno-project.tsx`, `components/banner.tsx`, and `app/project/[id]/project-content.tsx`. Verified the build runs successfully without issues.

---
*PR created automatically by Jules for task [18209320143158932060](https://jules.google.com/task/18209320143158932060) started by @AdityaKodez*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security across external links that open in new tabs by adding protective attributes. This prevents reverse tabnabbing attacks and ensures opened pages cannot access the original window, strengthening user privacy and application security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->