### PR TITLE
feat: add cursor-lit dot gutters beside the home frame

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -201,6 +201,41 @@ html[data-frame="wide"] {
   }
 
   /* -------------------------------------------------------------------------
+     Frame gutters (components/frame-gutters.tsx)
+
+     Dot-grid decoration for the dead space either side of the centered column
+     on wide viewports. Drawn entirely with background gradients — no borders,
+     so the gutters never double up on an edge the frame already owns (§10).
+     Colors come from theme tokens so both themes track on their own.
+  ------------------------------------------------------------------------- */
+  .frame-gutter-dots {
+    background-image: radial-gradient(
+      color-mix(in oklab, var(--muted-foreground) 24%, transparent) 1px,
+      transparent 1px
+    );
+    background-size: 14px 14px;
+  }
+
+  /* The same grid in the accent color, revealed only inside a soft circle
+     around the pointer. Origin and size have to match `.frame-gutter-dots`
+     exactly, or the lit dots drift off the muted ones underneath.
+     `--gutter-x/y` are written per band by components/frame-gutters.tsx. */
+  .frame-gutter-dots-lit {
+    background-image: radial-gradient(
+      color-mix(in oklab, var(--primary) 75%, transparent) 1px,
+      transparent 1px
+    );
+    background-size: 14px 14px;
+    opacity: var(--gutter-lit, 0);
+    mask-image: radial-gradient(
+      circle 7.5rem at var(--gutter-x, -50%) var(--gutter-y, -50%),
+      black,
+      transparent 70%
+    );
+    transition: opacity var(--motion-duration-slow) var(--motion-ease-standard);
+  }
+
+  /* -------------------------------------------------------------------------
      Preview box (app/components/[id]/preview-box.tsx)
 
      Both panes stay mounted in one grid cell for the lifetime of the box.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { ComponentHighlights } from "@/components/component-highlights";
 import { CTA } from "@/components/cta";
 import { Experience } from "@/components/experience";
 import { Footer } from "@/components/footer";
+import { FrameGutters } from "@/components/frame-gutters";
 import { GitHubSection } from "@/components/github-section";
 import { Hero } from "@/components/hero";
 import { HowIWork } from "@/components/how-i-work";
@@ -51,6 +52,8 @@ export default function Home() {
 
   return (
     <>
+      <FrameGutters />
+
       <main
         id="main-content"
         className="relative min-h-dvh gap-y-4 flex flex-col max-w-3xl mx-auto border-x border-b-2 overflow-x-clip pt-8"

--- a/components/frame-gutters.tsx
+++ b/components/frame-gutters.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useEffect, useRef } from "react";
+
+/**
+ * Decoration for the dead space either side of the centered column.
+ *
+ * A fixed, inert layer that hangs a dot field off each frame edge. Both bands
+ * are anchored to `--frame-max-w`, so they track the column rather than the
+ * viewport and stay aligned on routes that widen the frame.
+ *
+ * The grid is drawn twice per band — a muted base layer and an accent layer
+ * revealed through a soft circle that follows the pointer, so the dots light up
+ * under the cursor. Pointer coordinates are written straight to the accent
+ * layer's style as CSS variables, which keeps the effect off React's render
+ * path.
+ *
+ * Only shown from `xl` up: below that the gutter is narrower than the section
+ * rail's reach and the bands would crowd it.
+ */
+
+/** 12rem of band, faded top and bottom so it never runs into the header. */
+const BAND =
+  "absolute inset-y-0 w-48 [mask-image:linear-gradient(to_bottom,transparent,black_6rem,black_calc(100%_-_6rem),transparent)]";
+
+/** Fades the field out toward the viewport edge. Sits on the wrapper so the
+ *  lit layer can spend its own mask on the pointer circle. */
+const FIELD_FADE = {
+  left: "[mask-image:linear-gradient(to_left,black,transparent_78%)]",
+  right: "[mask-image:linear-gradient(to_right,black,transparent_78%)]",
+};
+
+export function FrameGutters() {
+  const leftLit = useRef<HTMLDivElement>(null);
+  const rightLit = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // No hover-capable pointer, nothing to light up.
+    if (!window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
+
+    // The bands are fixed, so their boxes only move on resize — measure once
+    // and reuse instead of reading layout on every pointer sample.
+    let boxes: { el: HTMLDivElement; left: number; top: number }[] = [];
+    const measure = () => {
+      boxes = [];
+      for (const el of [leftLit.current, rightLit.current]) {
+        if (!el) continue;
+        const rect = el.getBoundingClientRect();
+        boxes.push({ el, left: rect.left, top: rect.top });
+      }
+    };
+
+    let frame = 0;
+    let clientX = 0;
+    let clientY = 0;
+
+    const paint = () => {
+      frame = 0;
+      for (const { el, left, top } of boxes) {
+        el.style.setProperty("--gutter-x", `${clientX - left}px`);
+        el.style.setProperty("--gutter-y", `${clientY - top}px`);
+        el.style.setProperty("--gutter-lit", "1");
+      }
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      clientX = event.clientX;
+      clientY = event.clientY;
+      if (frame === 0) frame = requestAnimationFrame(paint);
+    };
+
+    const dim = () => {
+      for (const { el } of boxes) el.style.setProperty("--gutter-lit", "0");
+    };
+
+    measure();
+    window.addEventListener("pointermove", onPointerMove, { passive: true });
+    window.addEventListener("resize", measure);
+    document.documentElement.addEventListener("pointerleave", dim);
+    window.addEventListener("blur", dim);
+
+    return () => {
+      if (frame !== 0) cancelAnimationFrame(frame);
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("resize", measure);
+      document.documentElement.removeEventListener("pointerleave", dim);
+      window.removeEventListener("blur", dim);
+    };
+  }, []);
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none fixed inset-0 z-0 hidden select-none overflow-hidden xl:block"
+    >
+      <div className="relative mx-auto h-full w-full max-w-[var(--frame-max-w)]">
+        <div className={cn(BAND, "right-full")}>
+          <div className={cn("absolute inset-0", FIELD_FADE.left)}>
+            <div className="frame-gutter-dots absolute inset-0" />
+            <div
+              ref={leftLit}
+              className="frame-gutter-dots-lit absolute inset-0"
+            />
+          </div>
+        </div>
+
+        <div className={cn(BAND, "left-full")}>
+          <div className={cn("absolute inset-0", FIELD_FADE.right)}>
+            <div className="frame-gutter-dots absolute inset-0" />
+            <div
+              ref={rightLit}
+              className="frame-gutter-dots-lit absolute inset-0"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/posthog-provider.tsx
+++ b/components/posthog-provider.tsx
@@ -17,12 +17,6 @@ if (typeof window !== "undefined") {
       capture_pageview: false, // Handled manually by PostHogPageView for App Router accuracy
       capture_pageleave: true,
       autocapture: true,
-      loaded: (ph) => {
-        if (process.env.NODE_ENV === "development") {
-          ph.debug();
-          console.log("[PostHog] Initialized in debug mode.");
-        }
-      },
     });
   } else if (process.env.NODE_ENV === "development") {
     console.warn(

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -94,9 +94,6 @@ export function trackEvent<K extends keyof EventMap>(
 ): void {
   if (typeof window === "undefined") return;
   try {
-    if (process.env.NODE_ENV === "development") {
-      console.log(`[PostHog Event] ${eventName}`, properties);
-    }
     posthog.capture(eventName, properties);
   } catch (err) {
     if (process.env.NODE_ENV === "development") {


### PR DESCRIPTION
Fill the dead space either side of the centered column on xl+ with a dot grid anchored to --frame-max-w. A second grid in the accent color is revealed through a soft circle that follows the pointer, driven by CSS vars written per frame so React never re-renders on mouse move. Skipped when there is no fine pointer.

Also drop the PostHog development console logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive dot-grid decorations along the page frame gutters on larger screens.
  * Added pointer-following accent lighting with theme-aware fading and transitions.

* **Bug Fixes**
  * Reduced unnecessary console output during analytics initialization and event tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->